### PR TITLE
Do not exit the application in case the settings cannot be read

### DIFF
--- a/FroniusMonitor/App.xaml.cs
+++ b/FroniusMonitor/App.xaml.cs
@@ -9,7 +9,6 @@ public partial class App
     private static readonly Mutex mutex = new(true, $"{Environment.UserName}_HomeAutomationControlCenter");
     public static bool HaveSettings = true;
     public static readonly IServiceCollection ServiceCollection = new ServiceCollection();
-    public static Timer? SolarSystemQueryTimer;
 
     static App()
     {

--- a/FroniusMonitor/Models/Settings.cs
+++ b/FroniusMonitor/Models/Settings.cs
@@ -36,7 +36,8 @@ public class Settings : SettingsBase
     {
         lock (settingsLockObject)
         {
-            UpdateChecksum(App.Settings.WattPilotConnection, App.Settings.FritzBoxConnection, App.Settings.FroniusConnection, App.Settings.FroniusConnection2, App.Settings.ToshibaAcConnection);
+            UpdateChecksum(App.Settings.WattPilotConnection, App.Settings.FritzBoxConnection,
+                App.Settings.FroniusConnection, App.Settings.FroniusConnection2, App.Settings.ToshibaAcConnection);
             var serializer = new XmlSerializer(typeof(Settings));
             Directory.CreateDirectory(App.PerUserDataDir);
             using var stream = new FileStream(fileName, FileMode.Create, FileAccess.Write, FileShare.None);
@@ -57,18 +58,10 @@ public class Settings : SettingsBase
     {
         lock (settingsLockObject)
         {
-            try
-            {
-                App.SolarSystemQueryTimer = new(_ => { Environment.Exit(0); }, null, 10000, -1);
-                var serializer = new XmlSerializer(typeof(Settings));
-                using var stream = new FileStream(fileName, FileMode.Open, FileAccess.Read, FileShare.Read);
-                App.Settings = serializer.Deserialize(stream) as Settings ?? new Settings();
-                ClearIncorrectPasswords(App.Settings.WattPilotConnection, App.Settings.FritzBoxConnection, App.Settings.FroniusConnection);
-            }
-            finally
-            {
-                App.SolarSystemQueryTimer?.Dispose();
-            }
+            var serializer = new XmlSerializer(typeof(Settings));
+            using var stream = new FileStream(fileName, FileMode.Open, FileAccess.Read, FileShare.Read);
+            App.Settings = serializer.Deserialize(stream) as Settings ?? new Settings();
+            ClearIncorrectPasswords(App.Settings.WattPilotConnection, App.Settings.FritzBoxConnection, App.Settings.FroniusConnection);
         }
     }).ConfigureAwait(false);
 


### PR DESCRIPTION
Previously, issues such as deserialization problems or the absence of
the settings file would trigger an exception, leading to a forcefully
application termination.

This patch addresses this issue by removing the timer that triggers the
application exit, since the calling code is fully exception-aware. This
also allows application resources to perform any cleanup or finalization
necessary once the user closes the application.