### PR TITLE
Replace hard to read regular expression for parsing IP addresses with C# code

### DIFF
--- a/FroniusUnitTests/Gen24ModbusSettingsTests.cs
+++ b/FroniusUnitTests/Gen24ModbusSettingsTests.cs
@@ -1,0 +1,40 @@
+namespace FroniusUnitTests;
+
+[TestFixture]
+public class Gen24ModbusSettingsTests
+{
+    [Test]
+    public void IpAddress_SetValidValue_ShouldNotThrowException()
+    {
+        var settings = new Gen24ModbusSettings();
+
+        // Allow null and empty address
+        Assert.DoesNotThrow(() => settings.IpAddress = "");
+        Assert.DoesNotThrow(() => settings.IpAddress = null);
+
+        // Individual IPv4 Address
+        Assert.DoesNotThrow(() => settings.IpAddress = "192.168.1.1");
+        Assert.DoesNotThrow(() => settings.IpAddress = "10.0.0.100");
+        Assert.DoesNotThrow(() => settings.IpAddress = "172.16.0.10");
+
+        // IPv4 Address with Subnet Mask (CIDR Notation)
+        Assert.DoesNotThrow(() => settings.IpAddress = "192.168.1.0/24");
+        Assert.DoesNotThrow(() => settings.IpAddress = "10.0.0.0/8");
+        Assert.DoesNotThrow(() => settings.IpAddress = "172.16.0.0/16");
+
+        // Multiple IPv4 Addresses and Subnet Masks separated by Commas
+        Assert.DoesNotThrow(() => settings.IpAddress = "192.168.1.1,10.0.0.100,172.16.0.10");
+        Assert.DoesNotThrow(() => settings.IpAddress = "192.168.1.0/24,10.0.0.0/8,172.16.0.0/16");
+        Assert.DoesNotThrow(() => settings.IpAddress = "192.168.1.1,10.0.0.100,172.16.0.10,"
+           + "192.168.1.0/24,10.0.0.0/8,172.16.0.0/16");
+    }
+
+    [Test]
+    public void IpAddress_SetInvalidValue_ShouldThrowArgumentException()
+    {
+        var settings = new Gen24ModbusSettings();
+
+        Assert.Throws<ArgumentException>(() => settings.IpAddress = "InvalidIpAddress");
+        Assert.Throws<ArgumentException>(() => settings.IpAddress = "InvalidIpAddress/24");
+    }
+}

--- a/FroniusUnitTests/GlobalUsings.cs
+++ b/FroniusUnitTests/GlobalUsings.cs
@@ -1,3 +1,5 @@
 // Global using directives
 
+global using De.Hochstaetter.Fronius.Models.Gen24.Settings;
 global using NUnit.Framework;
+global using System;

--- a/FroniusUnitTests/UnitTest1.cs
+++ b/FroniusUnitTests/UnitTest1.cs
@@ -1,9 +1,0 @@
-using De.Hochstaetter.Fronius.Contracts;
-using De.Hochstaetter.Fronius.Models.Gen24.Settings;
-using De.Hochstaetter.Fronius.Services;
-
-namespace FroniusUnitTests;
-
-public class Tests
-{
-}


### PR DESCRIPTION
This pull request consists of two commits, first introduces and auto test for the regular expression in use. The second commit than changes the regular expression to use c# code instead (based on the unit test), which I hope improves readability.