### PR TITLE
Fix Null Reference exception when second Gen24 configuration is missing

### DIFF
--- a/Fronius/Services/DataCollectionService.cs
+++ b/Fronius/Services/DataCollectionService.cs
@@ -422,8 +422,8 @@ public class DataCollectionService : BindableBase, IDataCollectionService
                     await UpdateConfigData(HomeAutomationSystem, tokenSource.Token).ConfigureAwait(false);
                 }
 
-                var gen24Task = froniusCounter % FroniusUpdateRate == 0 ? TryGetGen24System(WebClientService, HomeAutomationSystem.Gen24Config!.Components, tokenSource.Token) : Task.FromResult<Gen24Sensors?>(null);
-                var gen24Task2 = froniusCounter++ % FroniusUpdateRate == 0 ? TryGetGen24System(WebClientService2, HomeAutomationSystem.Gen24Config2!.Components, tokenSource.Token) : Task.FromResult<Gen24Sensors?>(null);
+                var gen24Task = froniusCounter % FroniusUpdateRate == 0 ? TryGetGen24System(WebClientService, HomeAutomationSystem.Gen24Config?.Components, tokenSource.Token) : Task.FromResult<Gen24Sensors?>(null);
+                var gen24Task2 = froniusCounter++ % FroniusUpdateRate == 0 ? TryGetGen24System(WebClientService2, HomeAutomationSystem.Gen24Config2?.Components, tokenSource.Token) : Task.FromResult<Gen24Sensors?>(null);
 
                 if (WebClientService.FritzBoxConnection == null && SwitchableDevices.Any(d => d is FritzBoxDevice))
                 {


### PR DESCRIPTION
This commit addresses a null reference exception that occurred when the
second Gen24 configuration was not present. Remove the warning suppression
and use conditional access instead, as the absence of the second Gen24
configuration is a valid scenario (e.g., when no other Gen24 is configured
in the settings dialog).