### PR TITLE
Split IWebClientService into IGen24Service and IFritzBoxService

### DIFF
--- a/Fronius/Contracts/IDataCollectionService.cs
+++ b/Fronius/Contracts/IDataCollectionService.cs
@@ -5,8 +5,9 @@
         HomeAutomationSystem? HomeAutomationSystem { get; }
         WebConnection? WattPilotConnection { get; set; }
         public IToshibaHvacService HvacService { get; }
-        public IWebClientService WebClientService { get; }
-        public IWebClientService? WebClientService2 { get; set; }
+        public IGen24Service Gen24Service { get; }
+        public IGen24Service? Gen24Service2 { get; set; }
+        public IFritzBoxService FritzBoxService { get; }
         public BindableCollection<ISwitchable>? SwitchableDevices { get; }
 
         public int FroniusUpdateRate { get; set; }
@@ -14,7 +15,7 @@
 
         event EventHandler<SolarDataEventArgs>? NewDataReceived;
 
-        Task Start(WebConnection? inverterConnection, WebConnection? inverter2Connection, WebConnection? fritzBoxConnection, WebConnection? wattPilotConnection);
+        Task Start(WebConnection? gen24WebConnection, WebConnection? gen24WebConnection2, WebConnection? fritzBoxConnection, WebConnection? wattPilotConnection);
         void Stop();
         void SuspendPowerConsumers();
         void ResumePowerConsumers();

--- a/Fronius/Contracts/IFritzBoxService.cs
+++ b/Fronius/Contracts/IFritzBoxService.cs
@@ -1,0 +1,13 @@
+﻿namespace De.Hochstaetter.Fronius.Contracts;
+
+public interface IFritzBoxService
+{
+    WebConnection? Connection { get; set; }
+    ValueTask FritzBoxLogin(CancellationToken token = default);
+    ValueTask<FritzBoxDeviceList> GetFritzBoxDevices(CancellationToken token = default);
+    ValueTask TurnOnFritzBoxDevice(string ain, CancellationToken token = default);
+    ValueTask TurnOffFritzBoxDevice(string ain, CancellationToken token = default);
+    ValueTask SetFritzBoxLevel(string ain, double level, CancellationToken token = default);
+    ValueTask SetFritzBoxColorTemperature(string ain, double temperatureKelvin, CancellationToken token = default);
+    ValueTask SetFritzBoxColor(string ain, double hueDegrees, double saturation, CancellationToken token = default);
+}

--- a/Fronius/Contracts/IGen24Service.cs
+++ b/Fronius/Contracts/IGen24Service.cs
@@ -2,19 +2,11 @@
 
 namespace De.Hochstaetter.Fronius.Contracts;
 
-public interface IWebClientService
+public interface IGen24Service
 {
-    WebConnection? InverterConnection { get; set; }
-    WebConnection? FritzBoxConnection { get; set; }
+    WebConnection? Connection { get; set; }
     Task<Gen24Sensors> GetFroniusData(Gen24Components components, CancellationToken token = default);
     ValueTask<T?> SendFroniusCommand<T>(string request, JToken? jToken = null, CancellationToken token = default) where T : Gen24NoResultCommand, new();
-    ValueTask FritzBoxLogin(CancellationToken token = default);
-    ValueTask<FritzBoxDeviceList> GetFritzBoxDevices(CancellationToken token = default);
-    ValueTask TurnOnFritzBoxDevice(string ain, CancellationToken token = default);
-    ValueTask TurnOffFritzBoxDevice(string ain, CancellationToken token = default);
-    ValueTask SetFritzBoxLevel(string ain, double level, CancellationToken token = default);
-    ValueTask SetFritzBoxColorTemperature(string ain, double temperatureKelvin, CancellationToken token = default);
-    ValueTask SetFritzBoxColor(string ain, double hueDegrees, double saturation, CancellationToken token = default);
     ValueTask<IOrderedEnumerable<Gen24Event>> GetFroniusEvents(CancellationToken token = default);
     ValueTask<T> ReadGen24Entity<T>(string request, CancellationToken token = default) where T : new();
     ValueTask<(string JsonString, HttpStatusCode StatusCode)> GetFroniusStringResponse(string request, JToken? jToken = null, IEnumerable<HttpStatusCode>? allowedStatusCodes = null, CancellationToken token = default);

--- a/Fronius/Contracts/IScoped.cs
+++ b/Fronius/Contracts/IScoped.cs
@@ -2,5 +2,5 @@
 
 public interface IInverterScoped
 {
-    IWebClientService WebClientService { get; }
+    IGen24Service Gen24Service { get; }
 }

--- a/Fronius/Models/FritzBoxDevice.cs
+++ b/Fronius/Models/FritzBoxDevice.cs
@@ -48,7 +48,7 @@ public class FritzBoxDevice : BindableBase, IPowerConsumer1P
     private bool wasSwitched;
 
     [XmlIgnore]
-    public IWebClientService? WebClientService { private get; set; }
+    public IFritzBoxService? FritzBoxService { private get; set; }
 
     private uint id;
     [XmlAttribute("id")]
@@ -242,38 +242,38 @@ public class FritzBoxDevice : BindableBase, IPowerConsumer1P
 
         if (turnOn)
         {
-            await WebClientService!.TurnOnFritzBoxDevice(Ain).ConfigureAwait(false);
+            await FritzBoxService!.TurnOnFritzBoxDevice(Ain).ConfigureAwait(false);
         }
         else
         {
-            await WebClientService!.TurnOffFritzBoxDevice(Ain).ConfigureAwait(false);
+            await FritzBoxService!.TurnOffFritzBoxDevice(Ain).ConfigureAwait(false);
         }
     }
 
     public async Task SetLevel(double level)
     {
         InitiateSwitching();
-        await WebClientService!.SetFritzBoxLevel(Ain, level).ConfigureAwait(false);
+        await FritzBoxService!.SetFritzBoxLevel(Ain, level).ConfigureAwait(false);
     }
 
     public async Task SetHsv(double hueDegrees, double saturation, double value)
     {
         InitiateSwitching();
-        await WebClientService!.SetFritzBoxColor(Ain, hueDegrees, saturation).ConfigureAwait(false);
-        await WebClientService!.SetFritzBoxLevel(Ain, value).ConfigureAwait(false);
+        await FritzBoxService!.SetFritzBoxColor(Ain, hueDegrees, saturation).ConfigureAwait(false);
+        await FritzBoxService!.SetFritzBoxLevel(Ain, value).ConfigureAwait(false);
     }
 
     public async Task SetColorTemperature(double colorTemperatureKelvin)
     {
         InitiateSwitching();
-        await WebClientService!.SetFritzBoxColorTemperature(Ain, colorTemperatureKelvin).ConfigureAwait(false);
+        await FritzBoxService!.SetFritzBoxColorTemperature(Ain, colorTemperatureKelvin).ConfigureAwait(false);
     }
 
     private void InitiateSwitching()
     {
-        if (WebClientService == null)
+        if (FritzBoxService == null)
         {
-            throw new InvalidOperationException("No WebClientService");
+            throw new InvalidOperationException("No FritzBoxService");
         }
 
         wasSwitched = true;

--- a/Fronius/Models/Gen24/Gen24Event.cs
+++ b/Fronius/Models/Gen24/Gen24Event.cs
@@ -12,7 +12,7 @@ public enum Severity : byte
 
 public class Gen24Event : BindableBase
 {
-    private readonly IWebClientService webClientService = IoC.Get<IWebClientService>();
+    private readonly IGen24Service gen24Service = IoC.Get<IGen24Service>();
 
     private DateTime? activeUntil;
     [FroniusProprietaryImport("activeUntil", FroniusDataType.Root)]
@@ -56,7 +56,7 @@ public class Gen24Event : BindableBase
 
     public string Code => (string.IsNullOrEmpty(Prefix) ? string.Empty : $"{Prefix}-") + (EventId.HasValue ? EventId.Value.ToString(CultureInfo.InvariantCulture) : string.Empty);
 
-    public string Message => webClientService.GetEventDescription(Code).Result;
+    public string Message => gen24Service.GetEventDescription(Code).Result;
 
     private Severity severity;
     [FroniusProprietaryImport("severity", FroniusDataType.Root)]

--- a/Fronius/Services/DataCollectionService.cs
+++ b/Fronius/Services/DataCollectionService.cs
@@ -422,8 +422,8 @@ public class DataCollectionService : BindableBase, IDataCollectionService
                     await UpdateConfigData(HomeAutomationSystem, tokenSource.Token).ConfigureAwait(false);
                 }
 
-                var gen24Task = froniusCounter % FroniusUpdateRate == 0 ? TryGetGen24System(WebClientService, HomeAutomationSystem.Gen24Config!.Components, tokenSource.Token) : Task.FromResult<Gen24Sensors?>(null);
-                var gen24Task2 = froniusCounter++ % FroniusUpdateRate == 0 ? TryGetGen24System(WebClientService2, HomeAutomationSystem.Gen24Config2!.Components, tokenSource.Token) : Task.FromResult<Gen24Sensors?>(null);
+                var gen24Task = froniusCounter % FroniusUpdateRate == 0 ? TryGetGen24System(WebClientService, HomeAutomationSystem.Gen24Config?.Components, tokenSource.Token) : Task.FromResult<Gen24Sensors?>(null);
+                var gen24Task2 = froniusCounter++ % FroniusUpdateRate == 0 ? TryGetGen24System(WebClientService2, HomeAutomationSystem.Gen24Config2?.Components, tokenSource.Token) : Task.FromResult<Gen24Sensors?>(null);
 
                 if (WebClientService.FritzBoxConnection == null && SwitchableDevices.Any(d => d is FritzBoxDevice))
                 {

--- a/Fronius/Services/FritzBoxService.cs
+++ b/Fronius/Services/FritzBoxService.cs
@@ -1,0 +1,171 @@
+﻿namespace De.Hochstaetter.Fronius.Services;
+
+public class FritzBoxService : BindableBase, IFritzBoxService
+{
+    private string? fritzBoxSid;
+
+    private WebConnection? connection;
+
+    public WebConnection? Connection
+    {
+        get => connection;
+        set => Set(ref connection, value);
+    }
+
+
+    public async ValueTask FritzBoxLogin(CancellationToken token = default)
+    {
+        if (Connection == null)
+        {
+            throw new NullReferenceException(Resources.NoFritzBoxConnection);
+        }
+
+        var document = await GetXmlResponse("login_sid.lua", token: token);
+        var challenge = document.SelectSingleNode("/SessionInfo/Challenge")?.InnerText ?? throw new InvalidDataException("FritzBox did not supply challenge");
+        var text = challenge + "-" + Connection.Password;
+        var response = challenge + "-" + MD5.HashData(Encoding.Unicode.GetBytes(text)).Aggregate("", (current, next) => $"{current}{next:x2}");
+
+        var dict = new Dictionary<string, string>
+        {
+            { "username", Connection.UserName },
+            { "response", response }
+        };
+
+        document = await GetXmlResponse("login_sid.lua", dict, token);
+        fritzBoxSid = document.SelectSingleNode("/SessionInfo/SID")?.InnerText ?? throw new UnauthorizedAccessException(Resources.AccessDenied);
+
+        if (fritzBoxSid.All(c => c == '0'))
+        {
+            fritzBoxSid = null;
+            throw new UnauthorizedAccessException(Resources.AccessDenied);
+        }
+    }
+
+    public async ValueTask<FritzBoxDeviceList> GetFritzBoxDevices(CancellationToken token = default)
+    {
+        await using var stream = await GetStreamResponse("webservices/homeautoswitch.lua?switchcmd=getdevicelistinfos", token: token)
+            .ConfigureAwait(false) ?? throw new InvalidDataException();
+        var serializer = new XmlSerializer(typeof(FritzBoxDeviceList));
+        var result = serializer.Deserialize(stream) as FritzBoxDeviceList ?? throw new InvalidDataException();
+        result.Devices.Apply(d => d.FritzBoxService = this);
+        return result;
+    }
+
+    public async ValueTask TurnOnFritzBoxDevice(string ain, CancellationToken token = default)
+    {
+        ain = ain.Replace(" ", "", StringComparison.InvariantCulture);
+        using var _ = await GetFritzBoxResponse($"webservices/homeautoswitch.lua?ain={ain}&switchcmd=setswitchon", token: token).ConfigureAwait(false);
+    }
+
+    public async ValueTask TurnOffFritzBoxDevice(string ain, CancellationToken token = default)
+    {
+        ain = ain.Replace(" ", "", StringComparison.InvariantCulture);
+        using var _ = await GetFritzBoxResponse($"webservices/homeautoswitch.lua?ain={ain}&switchcmd=setswitchoff", token: token).ConfigureAwait(false);
+    }
+
+    public async ValueTask SetFritzBoxLevel(string ain, double level, CancellationToken token = default)
+    {
+        var byteLevel = Math.Max((byte)Math.Round(level * 255, MidpointRounding.AwayFromZero), (byte)2);
+        ain = ain.Replace(" ", "", StringComparison.InvariantCulture);
+        using var _ = await GetFritzBoxResponse($"webservices/homeautoswitch.lua?ain={ain}&switchcmd=setlevel&level={byteLevel}", token: token).ConfigureAwait(false);
+    }
+
+    public async ValueTask SetFritzBoxColorTemperature(string ain, double temperatureKelvin, CancellationToken token = default)
+    {
+        var intTemperature = (int)Math.Round(temperatureKelvin, MidpointRounding.AwayFromZero);
+        ain = ain.Replace(" ", "", StringComparison.InvariantCulture);
+        using var _ = await GetFritzBoxResponse($"webservices/homeautoswitch.lua?ain={ain}&switchcmd=setcolortemperature&temperature={intTemperature}&duration=0",
+            token: token).ConfigureAwait(false);
+    }
+
+
+    private static readonly Dictionary<int, IEnumerable<int>> allowedFritzBoxColors = new()
+    {
+        { 358, new[] { 180, 112, 54 } },
+        { 35, new[] { 214, 140, 72 } },
+        { 52, new[] { 153, 102, 51 } },
+        { 92, new[] { 123, 79, 38 } },
+        { 120, new[] { 160, 82, 38 } },
+        { 160, new[] { 145, 84, 41 } },
+        { 195, new[] { 179, 118, 59 } },
+        { 212, new[] { 169, 110, 56 } },
+        { 225, new[] { 204, 135, 67 } },
+        { 266, new[] { 169, 110, 54 } },
+        { 296, new[] { 140, 92, 46 } },
+        { 335, new[] { 180, 107, 51 } },
+    };
+
+    public async ValueTask SetFritzBoxColor(string ain, double hueDegrees, double saturation, CancellationToken token = default)
+    {
+        var intHue = allowedFritzBoxColors.Keys.MinBy(k => Math.Min(Math.Abs(hueDegrees - k), Math.Abs(hueDegrees + 360 - k)));
+        var intSaturation = allowedFritzBoxColors[intHue].MinBy(s => Math.Abs(s - saturation * 255));
+        ain = ain.Replace(" ", "", StringComparison.InvariantCulture);
+        using var _ = await GetFritzBoxResponse($"webservices/homeautoswitch.lua?ain={ain}&switchcmd=setcolor&hue={intHue}&saturation={intSaturation}&duration=0",
+            token: token).ConfigureAwait(false);
+    }
+
+    private async ValueTask<HttpResponseMessage> GetFritzBoxResponse(string request, IEnumerable<KeyValuePair<string, string>>? postVariables = null,
+        CancellationToken token = default)
+    {
+        HttpResponseMessage response;
+
+        if (fritzBoxSid == null && !request.StartsWith("login_sid.lua"))
+        {
+            await FritzBoxLogin(token).ConfigureAwait(false);
+        }
+
+        while (true)
+        {
+            if (Connection == null)
+            {
+                throw new NullReferenceException(Resources.NoSystemConnection);
+            }
+
+            var requestString = $"{Connection.BaseUrl}/{request}{(fritzBoxSid == null || request.StartsWith("login_sid.lua") ? string.Empty : $"&sid={fritzBoxSid}")}";
+
+            using var client = new HttpClient
+            (
+                new HttpClientHandler { ServerCertificateCustomValidationCallback = (_, _, _, _) => true, }
+            );
+
+            // ReSharper disable once PossibleMultipleEnumeration
+            response = postVariables == null
+                ? await client.GetAsync(requestString, token).ConfigureAwait(false)
+                : await client.PostAsync(requestString, new FormUrlEncodedContent(postVariables), token).ConfigureAwait(false);
+
+            if (response.StatusCode == HttpStatusCode.Forbidden)
+            {
+                await FritzBoxLogin(token).ConfigureAwait(false);
+                continue;
+            }
+
+            response.EnsureSuccessStatusCode();
+            break;
+        }
+
+        return response;
+    }
+
+    private async ValueTask<Stream> GetStreamResponse(string request, IEnumerable<KeyValuePair<string, string>>? postVariables = null, CancellationToken token = default)
+    {
+        var response = await GetFritzBoxResponse(request, postVariables, token).ConfigureAwait(false);
+        return await response.Content.ReadAsStreamAsync(token).ConfigureAwait(false);
+    }
+
+    [SuppressMessage("ReSharper", "UnusedMember.Local")]
+#pragma warning disable IDE0051
+    private async ValueTask<string> GetStringResponse(string request)
+    {
+        var response = await GetFritzBoxResponse(request).ConfigureAwait(false);
+        return await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+    }
+#pragma warning restore IDE0051
+
+    private async ValueTask<XmlDocument> GetXmlResponse(string request, IEnumerable<KeyValuePair<string, string>>? postVariables = null, CancellationToken token = default)
+    {
+        await using var stream = await GetStreamResponse(request, postVariables, token).ConfigureAwait(false);
+        var result = new XmlDocument();
+        result.Load(stream);
+        return result;
+    }
+}

--- a/FroniusMonitor/App.xaml.cs
+++ b/FroniusMonitor/App.xaml.cs
@@ -52,7 +52,8 @@ public partial class App
         }
 
         var injector = ServiceCollection
-            .AddScoped<IWebClientService, WebClientService>()
+            .AddScoped<IGen24Service, Gen24Service>()
+            .AddScoped<IFritzBoxService, FritzBoxService>()
             .AddSingleton(SynchronizationContext.Current!)
             .AddSingleton<IDataCollectionService, DataCollectionService>()
             .AddSingleton<MainWindow>()

--- a/FroniusMonitor/ViewModels/EventLogViewModel.cs
+++ b/FroniusMonitor/ViewModels/EventLogViewModel.cs
@@ -2,11 +2,11 @@
 
 public class EventLogViewModel : ViewModelBase
 {
-    private readonly IWebClientService webClientService;
+    private readonly IGen24Service gen24Service;
 
-    public EventLogViewModel(IWebClientService webClientService)
+    public EventLogViewModel(IGen24Service gen24Service)
     {
-        this.webClientService = webClientService;
+        this.gen24Service = gen24Service;
     }
 
     private IOrderedEnumerable<Gen24Event>? events;
@@ -28,15 +28,15 @@ public class EventLogViewModel : ViewModelBase
     [SuppressMessage("ReSharper", "StringLiteralTypo")]
     internal override async Task OnInitialize()
     {
-        Title = await webClientService.GetUiString("EVENTLOG.TITLE").ConfigureAwait(false);
+        Title = await gen24Service.GetUiString("EVENTLOG.TITLE").ConfigureAwait(false);
         await base.OnInitialize().ConfigureAwait(false);
-        var inverterBaseSettings = await webClientService.ReadGen24Entity<Gen24InverterSettings>("config/common").ConfigureAwait(false);
+        var inverterBaseSettings = await gen24Service.ReadGen24Entity<Gen24InverterSettings>("config/common").ConfigureAwait(false);
 
         if (!string.IsNullOrWhiteSpace(inverterBaseSettings.SystemName))
         {
             Title += $" - {inverterBaseSettings.SystemName}";
         }
 
-        Events = await webClientService.GetFroniusEvents().ConfigureAwait(false);
+        Events = await gen24Service.GetFroniusEvents().ConfigureAwait(false);
     }
 }

--- a/FroniusMonitor/ViewModels/InverterSettingsViewModel.cs
+++ b/FroniusMonitor/ViewModels/InverterSettingsViewModel.cs
@@ -5,7 +5,10 @@
     {
         private Gen24InverterSettings oldSettings = null!;
 
-        public InverterSettingsViewModel(IDataCollectionService dataCollectionService, IWebClientService webClientService, IGen24JsonService gen24Service, IWattPilotService wattPilotService) : base(dataCollectionService, webClientService, gen24Service, wattPilotService) { }
+        public InverterSettingsViewModel(IDataCollectionService dataCollectionService, IGen24Service gen24Service,
+                IGen24JsonService gen24JsonService, IFritzBoxService fritzBoxService, IWattPilotService wattPilotService)
+            : base(dataCollectionService, gen24Service, gen24JsonService, fritzBoxService, wattPilotService)
+        { }
 
         private ICommand? undoCommand;
         public ICommand UndoCommand => undoCommand ??= new NoParameterCommand(Undo);
@@ -207,23 +210,23 @@
 
                 PowerModes = new[]
                 {
-                    new ListItemModel<MpptPowerMode> { Value = MpptPowerMode.Off, DisplayName = await WebClientService.GetFroniusName(MpptPowerMode.Off).ConfigureAwait(false) },
-                    new ListItemModel<MpptPowerMode> { Value = MpptPowerMode.Auto, DisplayName = await WebClientService.GetFroniusName(MpptPowerMode.Auto).ConfigureAwait(false) },
-                    new ListItemModel<MpptPowerMode> { Value = MpptPowerMode.Fix, DisplayName = await WebClientService.GetFroniusName(MpptPowerMode.Fix).ConfigureAwait(false) },
+                    new ListItemModel<MpptPowerMode> { Value = MpptPowerMode.Off, DisplayName = await Gen24Service.GetFroniusName(MpptPowerMode.Off).ConfigureAwait(false) },
+                    new ListItemModel<MpptPowerMode> { Value = MpptPowerMode.Auto, DisplayName = await Gen24Service.GetFroniusName(MpptPowerMode.Auto).ConfigureAwait(false) },
+                    new ListItemModel<MpptPowerMode> { Value = MpptPowerMode.Fix, DisplayName = await Gen24Service.GetFroniusName(MpptPowerMode.Fix).ConfigureAwait(false) },
                 };
 
                 DynamicPeakManagerModes = new[]
                 {
-                    new ListItemModel<MpptOnOff> { Value = MpptOnOff.Off, DisplayName = await WebClientService.GetFroniusName(MpptOnOff.Off).ConfigureAwait(false) },
-                    new ListItemModel<MpptOnOff> { Value = MpptOnOff.On, DisplayName = await WebClientService.GetFroniusName(MpptOnOff.On).ConfigureAwait(false) },
-                    new ListItemModel<MpptOnOff> { Value = MpptOnOff.OnMlsd, DisplayName = await WebClientService.GetFroniusName(MpptOnOff.OnMlsd).ConfigureAwait(false) },
+                    new ListItemModel<MpptOnOff> { Value = MpptOnOff.Off, DisplayName = await Gen24Service.GetFroniusName(MpptOnOff.Off).ConfigureAwait(false) },
+                    new ListItemModel<MpptOnOff> { Value = MpptOnOff.On, DisplayName = await Gen24Service.GetFroniusName(MpptOnOff.On).ConfigureAwait(false) },
+                    new ListItemModel<MpptOnOff> { Value = MpptOnOff.OnMlsd, DisplayName = await Gen24Service.GetFroniusName(MpptOnOff.OnMlsd).ConfigureAwait(false) },
                 };
 
                 PowerLimitModes = new[]
                 {
-                    new ListItemModel<PowerLimitMode> { Value = PowerLimitMode.Off, DisplayName = await WebClientService.GetFroniusName(PowerLimitMode.Off).ConfigureAwait(false) },
-                    new ListItemModel<PowerLimitMode> { Value = PowerLimitMode.EntireSystem, DisplayName = await WebClientService.GetConfigString("EXPORTLIMIT.WLIM_MAX_W").ConfigureAwait(false) },
-                    new ListItemModel<PowerLimitMode> { Value = PowerLimitMode.WeakestPhase, DisplayName = await WebClientService.GetConfigString("EXPORTLIMIT.WLIM_MAX_FEEDIN_PER_PHASE").ConfigureAwait(false) },
+                    new ListItemModel<PowerLimitMode> { Value = PowerLimitMode.Off, DisplayName = await Gen24Service.GetFroniusName(PowerLimitMode.Off).ConfigureAwait(false) },
+                    new ListItemModel<PowerLimitMode> { Value = PowerLimitMode.EntireSystem, DisplayName = await Gen24Service.GetConfigString("EXPORTLIMIT.WLIM_MAX_W").ConfigureAwait(false) },
+                    new ListItemModel<PowerLimitMode> { Value = PowerLimitMode.WeakestPhase, DisplayName = await Gen24Service.GetConfigString("EXPORTLIMIT.WLIM_MAX_FEEDIN_PER_PHASE").ConfigureAwait(false) },
                 };
 
                 Undo();
@@ -265,17 +268,17 @@
                     }
                 }
 
-                var visualizationToken = Gen24Service.GetUpdateToken(Settings.PowerLimitSettings.Visualization, oldSettings.PowerLimitSettings.Visualization);
+                var visualizationToken = Gen24JsonService.GetUpdateToken(Settings.PowerLimitSettings.Visualization, oldSettings.PowerLimitSettings.Visualization);
                 visualizationToken.Add("exportLimits", new JObject { { "activePower", new JObject { { "displayModeSoftLimit", "absolute" } } }, });
 
-                var hardLimitToken = Gen24Service.GetUpdateToken(Settings.PowerLimitSettings.ExportLimits.ActivePower.HardLimit, oldSettings.PowerLimitSettings.ExportLimits.ActivePower.HardLimit);
-                var softLimitToken = Gen24Service.GetUpdateToken(Settings.PowerLimitSettings.ExportLimits.ActivePower.SoftLimit, oldSettings.PowerLimitSettings.ExportLimits.ActivePower.SoftLimit);
+                var hardLimitToken = Gen24JsonService.GetUpdateToken(Settings.PowerLimitSettings.ExportLimits.ActivePower.HardLimit, oldSettings.PowerLimitSettings.ExportLimits.ActivePower.HardLimit);
+                var softLimitToken = Gen24JsonService.GetUpdateToken(Settings.PowerLimitSettings.ExportLimits.ActivePower.SoftLimit, oldSettings.PowerLimitSettings.ExportLimits.ActivePower.SoftLimit);
 
-                var activePowerToken = Gen24Service.GetUpdateToken(Settings.PowerLimitSettings.ExportLimits.ActivePower, oldSettings.PowerLimitSettings.ExportLimits.ActivePower);
+                var activePowerToken = Gen24JsonService.GetUpdateToken(Settings.PowerLimitSettings.ExportLimits.ActivePower, oldSettings.PowerLimitSettings.ExportLimits.ActivePower);
                 activePowerToken.Add("hardLimit", hardLimitToken);
                 activePowerToken.Add("softLimit", softLimitToken);
 
-                var exportLimitsToken = Gen24Service.GetUpdateToken(Settings.PowerLimitSettings.ExportLimits, oldSettings.PowerLimitSettings.ExportLimits);
+                var exportLimitsToken = Gen24JsonService.GetUpdateToken(Settings.PowerLimitSettings.ExportLimits, oldSettings.PowerLimitSettings.ExportLimits);
                 exportLimitsToken.Add("activePower", activePowerToken);
 
                 var limitsToken = new JObject
@@ -315,7 +318,7 @@
                 {
                     if (newValues is not null && oldValues is not null)
                     {
-                        var updateToken = Gen24Service.GetUpdateToken(newValues, oldValues);
+                        var updateToken = Gen24JsonService.GetUpdateToken(newValues, oldValues);
 
                         if (updateToken.HasValues)
                         {
@@ -341,9 +344,9 @@
         [SuppressMessage("ReSharper", "StringLiteralTypo")]
         private async ValueTask<Gen24InverterSettings> ReadDataFromInverter()
         {
-            var mpptToken = (await WebClientService.GetFroniusJsonResponse("config/setup/powerunit/mppt").ConfigureAwait(false)).Token;
-            var commonToken = (await WebClientService.GetFroniusJsonResponse("config/common").ConfigureAwait(false)).Token;
-            var powerLimitToken = (await WebClientService.GetFroniusJsonResponse("config/powerlimits").ConfigureAwait(false)).Token;
+            var mpptToken = (await Gen24Service.GetFroniusJsonResponse("config/setup/powerunit/mppt").ConfigureAwait(false)).Token;
+            var commonToken = (await Gen24Service.GetFroniusJsonResponse("config/common").ConfigureAwait(false)).Token;
+            var powerLimitToken = (await Gen24Service.GetFroniusJsonResponse("config/powerlimits").ConfigureAwait(false)).Token;
             return Gen24InverterSettings.Parse(commonToken, mpptToken, powerLimitToken);
         }
 

--- a/FroniusMonitor/ViewModels/MainViewModel.cs
+++ b/FroniusMonitor/ViewModels/MainViewModel.cs
@@ -2,11 +2,11 @@
 
 public class MainViewModel : ViewModelBase
 {
-    private readonly IWebClientService webClientService;
+    private readonly IFritzBoxService fritzBoxService;
 
-    public MainViewModel(IDataCollectionService dataCollectionService, IWebClientService webClientService, IWattPilotService wattPilotService)
+    public MainViewModel(IDataCollectionService dataCollectionService, IFritzBoxService fritzBoxService, IWattPilotService wattPilotService)
     {
-        this.webClientService = webClientService;
+        this.fritzBoxService = fritzBoxService;
         DataCollectionService = dataCollectionService;
         WattPilotService = wattPilotService;
         ExportSettingsCommand = new NoParameterCommand(ExportSettings);
@@ -63,7 +63,7 @@ public class MainViewModel : ViewModelBase
 
     internal void FritzBoxVisibilityChanged(bool isVisible)
     {
-        webClientService.FritzBoxConnection = isVisible ? App.Settings.FritzBoxConnection : null;
+        fritzBoxService.Connection = isVisible ? App.Settings.FritzBoxConnection : null;
 
         if (isVisible)
         {

--- a/FroniusMonitor/ViewModels/ModbusViewModel.cs
+++ b/FroniusMonitor/ViewModels/ModbusViewModel.cs
@@ -4,8 +4,10 @@ public class ModbusViewModel : SettingsViewModelBase
 {
     private Gen24ModbusSettings oldSettings = null!;
 
-    public ModbusViewModel(IDataCollectionService dataCollectionService, IWebClientService webClientService, IGen24JsonService gen24JsonService, IWattPilotService wattPilotService)
-        : base(dataCollectionService, webClientService, gen24JsonService, wattPilotService) { }
+    public ModbusViewModel(IDataCollectionService dataCollectionService, IGen24Service gen24Service,
+            IGen24JsonService gen24JsonService, IFritzBoxService fritzBoxService, IWattPilotService wattPilotService)
+        : base(dataCollectionService, gen24Service, gen24JsonService, fritzBoxService, wattPilotService)
+    { }
 
     private Gen24ModbusSettings settings = null!;
 
@@ -71,7 +73,7 @@ public class ModbusViewModel : SettingsViewModelBase
 
             try
             {
-                var configToken = (await WebClientService.GetFroniusJsonResponse("config/", token: tokenSource.Token).ConfigureAwait(false)).Token;
+                var configToken = (await Gen24Service.GetFroniusJsonResponse("config/", token: tokenSource.Token).ConfigureAwait(false)).Token;
                 oldSettings = Gen24ModbusSettings.Parse(configToken["modbus"]);
                 inverterSettings = Gen24InverterSettings.Parse(configToken);
             }

--- a/FroniusMonitor/ViewModels/SettingsViewModel.cs
+++ b/FroniusMonitor/ViewModels/SettingsViewModel.cs
@@ -29,11 +29,12 @@ public class SettingsViewModel : SettingsViewModelBase
 
     public SettingsViewModel
     (
-        IWebClientService webClientService,
-        IGen24JsonService gen24Service,
+        IGen24Service gen24Service,
+        IGen24JsonService gen24JsonService,
+        IFritzBoxService fritzBoxService,
         IWattPilotService wattPilotService,
         IDataCollectionService dataCollectionService
-    ) : base(dataCollectionService, webClientService, gen24Service, wattPilotService)
+    ) : base(dataCollectionService, gen24Service, gen24JsonService, fritzBoxService, wattPilotService)
     {
     }
 
@@ -166,14 +167,14 @@ public class SettingsViewModel : SettingsViewModelBase
         }
 
         IoC.Get<MainViewModel>().NotifyOfPropertyChange(nameof(Settings));
-        WebClientService.FritzBoxConnection = Settings is { HaveFritzBox: true, ShowFritzBox: true } ? Settings.FritzBoxConnection : null;
-        WebClientService.InverterConnection = Settings.FroniusConnection;
+        FritzBoxService.Connection = Settings is { HaveFritzBox: true, ShowFritzBox: true } ? Settings.FritzBoxConnection : null;
+        Gen24Service.Connection = Settings.FroniusConnection;
 
         if (Settings.HaveTwoInverters)
         {
-            DataCollectionService.WebClientService2 ??= IoC.Injector!.CreateScope().ServiceProvider.GetRequiredService<IWebClientService>();
-            DataCollectionService.WebClientService2.FritzBoxConnection = WebClientService.FritzBoxConnection;
-            DataCollectionService.WebClientService2.InverterConnection = Settings.FroniusConnection2;
+            DataCollectionService.Gen24Service2 ??= IoC.Injector!.CreateScope().ServiceProvider.GetRequiredService<IGen24Service>();
+            DataCollectionService.FritzBoxService.Connection = FritzBoxService.Connection;
+            DataCollectionService.Gen24Service2.Connection = Settings.FroniusConnection2;
         }
 
         DataCollectionService.FroniusUpdateRate = Settings.FroniusUpdateRate;

--- a/FroniusMonitor/ViewModels/SettingsViewModelBase.cs
+++ b/FroniusMonitor/ViewModels/SettingsViewModelBase.cs
@@ -2,13 +2,15 @@
 
 public abstract class SettingsViewModelBase : ViewModelBase
 {
-    protected readonly IGen24JsonService Gen24Service;
+    protected readonly IGen24JsonService Gen24JsonService;
     protected readonly IWattPilotService WattPilotService;
 
-    protected SettingsViewModelBase(IDataCollectionService dataCollectionService, IWebClientService webClientService, IGen24JsonService gen24Service, IWattPilotService wattPilotService)
+    protected SettingsViewModelBase(IDataCollectionService dataCollectionService, IGen24Service gen24Service,
+        IGen24JsonService gen24JsonService, IFritzBoxService fritzBoxService, IWattPilotService wattPilotService)
     {
-        WebClientService = webClientService;
         Gen24Service = gen24Service;
+        Gen24JsonService = gen24JsonService;
+        FritzBoxService = fritzBoxService;
         WattPilotService = wattPilotService;
         DataCollectionService = dataCollectionService;
     }
@@ -21,7 +23,8 @@ public abstract class SettingsViewModelBase : ViewModelBase
         set => Set(ref dataCollectionService, value);
     }
 
-    public IWebClientService WebClientService { get; }
+    public IGen24Service Gen24Service { get; }
+    public IFritzBoxService FritzBoxService { get; }
 
     private string toastText = string.Empty;
 
@@ -45,7 +48,7 @@ public abstract class SettingsViewModelBase : ViewModelBase
 
         try
         {
-            result = await WebClientService.GetFroniusJsonResponse(uri, token, new[] { HttpStatusCode.OK, HttpStatusCode.BadRequest }).ConfigureAwait(false);
+            result = await Gen24Service.GetFroniusJsonResponse(uri, token, new[] { HttpStatusCode.OK, HttpStatusCode.BadRequest }).ConfigureAwait(false);
         }
         catch (Exception ex)
         {

--- a/FroniusMonitor/Views/EventLogView.xaml.cs
+++ b/FroniusMonitor/Views/EventLogView.xaml.cs
@@ -2,12 +2,12 @@
 
 public partial class EventLogView : IInverterScoped
 {
-    public EventLogView(EventLogViewModel viewModel, IWebClientService webClientService)
+    public EventLogView(EventLogViewModel viewModel, IGen24Service gen24Service)
     {
         InitializeComponent();
         DataContext = viewModel;
         viewModel.View = this;
-        WebClientService = webClientService;
+        Gen24Service = gen24Service;
 
         Loaded += async (_, _) =>
         {
@@ -17,5 +17,5 @@ public partial class EventLogView : IInverterScoped
     }
 
     public EventLogViewModel ViewModel => (EventLogViewModel)DataContext;
-    public IWebClientService WebClientService { get; }
+    public IGen24Service Gen24Service { get; }
 }

--- a/FroniusMonitor/Views/InverterSettingsView.xaml
+++ b/FroniusMonitor/Views/InverterSettingsView.xaml
@@ -97,7 +97,7 @@
             </GroupBox>
 
             <GroupBox Grid.Row="0" Grid.Column="1" Header="{l:Channel 'MPPT1'}" Margin="4,0,0,0"
-                      IsEnabled="{Binding WebClientService.InverterConnection.UserName, FallbackValue=customer, Converter={co:String2Bool Value=customer, Equal=False, NotEqual=True}}">
+                      IsEnabled="{Binding Gen24Service.Connection.UserName, FallbackValue=customer, Converter={co:String2Bool Value=customer, Equal=False, NotEqual=True}}">
                 <Grid>
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto" />
@@ -162,7 +162,7 @@
             </GroupBox>
 
             <GroupBox Grid.Row="0" Grid.Column="2" Header="{l:Channel 'MPPT2'}" Margin="4,0,0,0"
-                      IsEnabled="{Binding WebClientService.InverterConnection.UserName, FallbackValue=customer, Converter={co:String2Bool Value=customer, Equal=False, NotEqual=True}}">
+                      IsEnabled="{Binding Gen24Service.Connection.UserName, FallbackValue=customer, Converter={co:String2Bool Value=customer, Equal=False, NotEqual=True}}">
                 <Grid>
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto" />
@@ -226,7 +226,7 @@
                 </Grid>
             </GroupBox>
 
-            <GroupBox Visibility="{Binding WebClientService.InverterConnection.UserName, FallbackValue=Collapsed, Converter={co:String2Visibility Value=customer, Equal=Collapsed, NotEqual=Visible}}"
+            <GroupBox Visibility="{Binding Gen24Service.Connection.UserName, FallbackValue=Collapsed, Converter={co:String2Visibility Value=customer, Equal=Collapsed, NotEqual=Visible}}"
                       Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2" Header="{l:Config 'EXPORTLIMIT.TITEL'}" Margin="0,4,0,0">
                 <Grid>
                     <Grid.RowDefinitions>

--- a/FroniusMonitor/Views/InverterSettingsView.xaml.cs
+++ b/FroniusMonitor/Views/InverterSettingsView.xaml.cs
@@ -2,12 +2,12 @@
 
 public partial class InverterSettingsView : IInverterScoped
 {
-    public InverterSettingsView(InverterSettingsViewModel viewModel, IWebClientService webClientService)
+    public InverterSettingsView(InverterSettingsViewModel viewModel, IGen24Service gen24Service)
     {
         InitializeComponent();
         DataContext = viewModel;
         viewModel.View = this;
-        WebClientService = webClientService;
+        Gen24Service = gen24Service;
 
         Loaded += async (_, _) =>
         {
@@ -16,5 +16,5 @@ public partial class InverterSettingsView : IInverterScoped
         };
     }
 
-    public IWebClientService WebClientService { get; }
+    public IGen24Service Gen24Service { get; }
 }

--- a/FroniusMonitor/Views/MainWindow.xaml.cs
+++ b/FroniusMonitor/Views/MainWindow.xaml.cs
@@ -87,7 +87,7 @@ public partial class MainWindow
         (
             w => container == null ||
                  w is not IInverterScoped scoped ||
-                 scoped.WebClientService == container.GetRequiredService<IWebClientService>()
+                 scoped.Gen24Service == container.GetRequiredService<IGen24Service>()
         );
 
         if (view == null)

--- a/FroniusMonitor/Views/ModbusView.xaml.cs
+++ b/FroniusMonitor/Views/ModbusView.xaml.cs
@@ -2,12 +2,12 @@
 {
     public partial class ModbusView : IInverterScoped
     {
-        public ModbusView(ModbusViewModel viewModel, IWebClientService webClientService)
+        public ModbusView(ModbusViewModel viewModel, IGen24Service gen24Service)
         {
             InitializeComponent();
             viewModel.View = this;
             DataContext = viewModel;
-            WebClientService = webClientService;
+            Gen24Service = gen24Service;
 
             Loaded += async (_, _) =>
             {
@@ -16,6 +16,6 @@
             };
         }
 
-        public IWebClientService WebClientService { get; }
+        public IGen24Service Gen24Service { get; }
     }
 }

--- a/FroniusMonitor/Views/SelfConsumptionOptimizationView.xaml.cs
+++ b/FroniusMonitor/Views/SelfConsumptionOptimizationView.xaml.cs
@@ -2,12 +2,12 @@
 
 public partial class SelfConsumptionOptimizationView : IInverterScoped
 {
-    public SelfConsumptionOptimizationView(SelfConsumptionOptimizationViewModel viewModel, IWebClientService webClientService)
+    public SelfConsumptionOptimizationView(SelfConsumptionOptimizationViewModel viewModel, IGen24Service gen24Service)
     {
         InitializeComponent();
         DataContext = viewModel;
         viewModel.View = this;
-        WebClientService = webClientService;
+        Gen24Service = gen24Service;
 
         Loaded += async (_, _) =>
         {
@@ -16,5 +16,5 @@ public partial class SelfConsumptionOptimizationView : IInverterScoped
         };
     }
 
-    public IWebClientService WebClientService { get; }
+    public IGen24Service Gen24Service { get; }
 }

--- a/FroniusMonitor/Wpf/Localization/Gen24Localization.cs
+++ b/FroniusMonitor/Wpf/Localization/Gen24Localization.cs
@@ -31,15 +31,15 @@ public abstract class LocBase : UpdateableMarkupExtension
 
 public class Config : LocBase
 {
-    public Config(string path) : base(path, IoC.TryGetRegistered<IWebClientService>()?.GetConfigString(path)) { }
+    public Config(string path) : base(path, IoC.TryGetRegistered<IGen24Service>()?.GetConfigString(path)) { }
 }
 
 public class Ui : LocBase
 {
-    public Ui(string path) : base(path, IoC.TryGetRegistered<IWebClientService>()?.GetUiString(path)) { }
+    public Ui(string path) : base(path, IoC.TryGetRegistered<IGen24Service>()?.GetUiString(path)) { }
 }
 
 public class Channel : LocBase
 {
-    public Channel(string key) : base(key, IoC.TryGetRegistered<IWebClientService>()?.GetChannelString(key)) { }
+    public Channel(string key) : base(key, IoC.TryGetRegistered<IGen24Service>()?.GetChannelString(key)) { }
 }


### PR DESCRIPTION
This interface previously exhibited tight coupling between unrelated
web services, namely the Fritz!Box service and the Fronius Gen24 inverter
service. To address this, divide the interface into separate interfaces,
each with its corresponding implementation.
This commit also includes adjustments to all dependent code to align with
the new interfaces and implementations.