### PR TITLE
Fix Null Reference exception when Toshiba Ac Connection is missing

### DIFF
--- a/FroniusMonitor/ViewModels/SettingsViewModel.cs
+++ b/FroniusMonitor/ViewModels/SettingsViewModel.cs
@@ -50,7 +50,12 @@ public class SettingsViewModel : SettingsViewModelBase
     
     public ListItemModel<Protocol> SelectedProtocol
     {
-        get => AzureProtocols.First(p => p.Value == Settings.ToshibaAcConnection!.Protocol);
+        get => AzureProtocols.FirstOrDefault(p =>
+        {
+            if (Settings.ToshibaAcConnection == null)
+                return false;
+            return p.Value == Settings.ToshibaAcConnection.Protocol;
+        }, new ListItemModel<Protocol>());
         set
         {
             Settings.ToshibaAcConnection!.Protocol = value.Value;
@@ -61,7 +66,12 @@ public class SettingsViewModel : SettingsViewModelBase
 
     public ListItemModel<TunnelMode> SelectedTunnelMode
     {
-        get => TunnelModes.First(p => p.Value == Settings.ToshibaAcConnection!.TunnelMode);
+        get => TunnelModes.FirstOrDefault(p =>
+        {
+            if (Settings.ToshibaAcConnection == null)
+                return false;
+            return p.Value == Settings.ToshibaAcConnection.TunnelMode;
+        }, new ListItemModel<TunnelMode>());
         set
         {
             Settings.ToshibaAcConnection!.TunnelMode = value.Value;
@@ -69,7 +79,7 @@ public class SettingsViewModel : SettingsViewModelBase
         }
     }
 
-    public bool CanUseTunnel => Settings.ToshibaAcConnection!.CanUseTunnel;
+    public bool CanUseTunnel => Settings.ToshibaAcConnection?.CanUseTunnel ?? false;
 
     private Settings settings = null!;
 


### PR DESCRIPTION
This commit addresses some null reference exception that occurred when the Toshiba Ac Connection was not present. Remove the warning suppression and use null checks instead, as the absence of the Toshiba Ac Connection configuration is a valid scenario (e.g., when no Toshiba Ac Connection is configured in the settings dialog).