### PR TITLE
Fix Fritz!Box data task continuously throwing exceptions

### DIFF
--- a/Fronius/Services/DataCollectionService.cs
+++ b/Fronius/Services/DataCollectionService.cs
@@ -307,6 +307,9 @@ public class DataCollectionService : BindableBase, IDataCollectionService
     {
         try
         {
+            if (FritzBoxService.Connection == null)
+                return null;
+
             var devices = await FritzBoxService.GetFritzBoxDevices(token).ConfigureAwait(false);
 
             await Task.Run(() =>


### PR DESCRIPTION
This fix employs similar behavior as all other TryGet*|TryStart* methods. Initially, the Fritz!Box connection is checked, and if no connection is set up, the task returns null. Otherwise it will always throw from the FritzBoxService::FritzBoxLogin method, leading to no UI updates even if the Gen24 connection succeeded.