### PR TITLE
Add missing services to FroniusPhone app

### DIFF
--- a/FroniusPhone/MauiProgram.cs
+++ b/FroniusPhone/MauiProgram.cs
@@ -1,4 +1,6 @@
-﻿namespace FroniusPhone;
+﻿using De.Hochstaetter.Fronius.Models.Settings;
+
+namespace FroniusPhone;
 
 public static class MauiProgram
 {
@@ -36,6 +38,8 @@ public static class MauiProgram
             .AddSingleton<OverviewViewModel>()
             .AddSingleton<SettingsPage>()
             .AddSingleton<SettingsViewModel>()
+            .AddSingleton<SettingsBase>(new Settings())
+            .AddSingleton<IToshibaHvacService, ToshibaHvacService>()
             .AddSingleton(SynchronizationContext.Current ?? throw new InvalidOperationException("No Context"))
         ;
 


### PR DESCRIPTION
Starting the app inside the Pixel 5 Android emulator did not work due to the missing services.