### PR TITLE
Handle exceptions while deserializing the Drifts file

### DIFF
--- a/Fronius/Services/DataCollectionService.cs
+++ b/Fronius/Services/DataCollectionService.cs
@@ -93,9 +93,16 @@ public class DataCollectionService : BindableBase, IDataCollectionService
             return new List<SmartMeterCalibrationHistoryItem>();
         }
 
-        var serializer = new XmlSerializer(typeof(List<SmartMeterCalibrationHistoryItem>));
-        using var stream = new FileStream(settings.DriftFileName, FileMode.Open, FileAccess.Read, FileShare.Read);
-        return serializer.Deserialize(stream) as IList<SmartMeterCalibrationHistoryItem> ?? new List<SmartMeterCalibrationHistoryItem>();
+        try
+        {
+            var serializer = new XmlSerializer(typeof(List<SmartMeterCalibrationHistoryItem>));
+            using var stream = new FileStream(settings.DriftFileName, FileMode.Open, FileAccess.Read, FileShare.Read);
+            return serializer.Deserialize(stream) as IList<SmartMeterCalibrationHistoryItem> ?? new List<SmartMeterCalibrationHistoryItem>();
+        }
+        catch (Exception)
+        {
+            return new List<SmartMeterCalibrationHistoryItem>();
+        }
     });
 
     public Task<IList<SmartMeterCalibrationHistoryItem>> AddCalibrationHistoryItem(double consumedEnergyOffset, double producedEnergyOffset) => Task.Run(() =>


### PR DESCRIPTION
I have played with the classic Power Meter calibration to figure out
how to adjust the gap between the reported 1.8.0 grid consumption by
the Fronius Smart Meter and the actual value on the Power Meter from
the electricity network operator. After that I deleted all values in
the Drifts file, leading to exceptions thrown while de-serializing the
empty file and never recovering properly.