### PR TITLE
Fix exception bubbling up into user application

### DIFF
--- a/FroniusMonitor/ViewModels/EventLogViewModel.cs
+++ b/FroniusMonitor/ViewModels/EventLogViewModel.cs
@@ -28,15 +28,28 @@ public class EventLogViewModel : ViewModelBase
     [SuppressMessage("ReSharper", "StringLiteralTypo")]
     internal override async Task OnInitialize()
     {
-        Title = await gen24Service.GetUiString("EVENTLOG.TITLE").ConfigureAwait(false);
-        await base.OnInitialize().ConfigureAwait(false);
-        var inverterBaseSettings = await gen24Service.ReadGen24Entity<Gen24InverterSettings>("config/common").ConfigureAwait(false);
-
-        if (!string.IsNullOrWhiteSpace(inverterBaseSettings.SystemName))
+        try
         {
-            Title += $" - {inverterBaseSettings.SystemName}";
-        }
+            Title = await gen24Service.GetUiString("EVENTLOG.TITLE").ConfigureAwait(false);
+            await base.OnInitialize().ConfigureAwait(false);
+            var inverterBaseSettings = await gen24Service.ReadGen24Entity<Gen24InverterSettings>("config/common").ConfigureAwait(false);
 
-        Events = await gen24Service.GetFroniusEvents().ConfigureAwait(false);
+            if (!string.IsNullOrWhiteSpace(inverterBaseSettings.SystemName))
+            {
+                Title += $" - {inverterBaseSettings.SystemName}";
+            }
+
+            Events = await gen24Service.GetFroniusEvents().ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            ShowBox
+            (
+                string.Format(Resources.InverterCommReadError, ex is TaskCanceledException ? Loc.InverterTimeout : ex.Message),
+                    ex.GetType().Name, MessageBoxButton.OK, MessageBoxImage.Error
+            );
+
+            Close();
+        }
     }
 }


### PR DESCRIPTION
In case there is no inverter connection set-up, opening the event log window will throw an exception. Instead of covering this like in other windwows, the exception did show up in the application. Fix this like in other inverter related windows by showing a error message box with properly formated message.