### PR TITLE
Refactor settings loading into generic methods in SettingsBase

### DIFF
--- a/Fronius/GlobalUsings.cs
+++ b/Fronius/GlobalUsings.cs
@@ -13,6 +13,7 @@ global using System.Net.Sockets;
 global using System.Net.WebSockets;
 global using System.Reflection;
 global using System.Runtime.CompilerServices;
+global using System.Runtime.Serialization;
 global using System.Runtime.InteropServices;
 global using System.Security.Cryptography;
 global using System.Text;

--- a/Fronius/Models/Settings/SettingsBase.cs
+++ b/Fronius/Models/Settings/SettingsBase.cs
@@ -4,6 +4,74 @@ public abstract class SettingsBase : BindableBase, ICloneable
 {
     public event EventHandler<EventArgs>? SettingsChanged;
 
+    private static readonly SemaphoreSlim settingLock = new(1, 1);
+
+    protected static T Load<T>(string fileName) where T : SettingsBase, new()
+    {
+        settingLock.Wait();
+
+        try
+        {
+            using var stream = new FileStream(fileName, FileMode.Open, FileAccess.Read, FileShare.Read);
+            var serializer = new XmlSerializer(typeof(T));
+            var settings = serializer.Deserialize(stream) as T ?? throw new SerializationException();
+            ClearIncorrectPasswords(CollectWebConnections(settings).ToArray());
+            return settings;
+        }
+        finally
+        {
+            settingLock.Release();
+        }
+    }
+
+    protected static void Save<T>(T settings, string fileName) where T : SettingsBase, new()
+    {
+        settingLock.Wait();
+
+        try
+        {
+            UpdateChecksum(CollectWebConnections(settings).ToArray());
+            var serializer = new XmlSerializer(typeof(T));
+            using var stream = new FileStream(fileName, FileMode.Create, FileAccess.Write, FileShare.None);
+
+            using var writer = XmlWriter.Create(stream, new XmlWriterSettings
+            {
+                Encoding = Encoding.UTF8,
+                Indent = true,
+                IndentChars = new string(' ', 3),
+                NewLineChars = Environment.NewLine,
+            });
+
+            serializer.Serialize(writer, settings);
+        }
+        finally
+        {
+            settingLock.Release();
+        }
+    }
+
+    protected static IEnumerable<WebConnection?> CollectWebConnections<T>(T instance)
+    {
+        var connectionProperties = typeof(T)
+            .GetProperties()
+            .Where(prop => typeof(WebConnection).IsAssignableFrom(prop.PropertyType))
+            .Select(prop => (WebConnection?)prop.GetValue(instance));
+
+        var collectionProperties = typeof(T)
+            .GetProperties()
+            .Where(prop => typeof(IEnumerable<WebConnection>).IsAssignableFrom(prop.PropertyType))
+            .SelectMany(prop =>
+            {
+                if (prop.GetValue(instance) is IEnumerable<WebConnection> collection)
+                {
+                    return collection.Select(connection => (WebConnection?)connection);
+                }
+                return Enumerable.Empty<WebConnection?>();
+            });
+
+        return connectionProperties.Concat(collectionProperties);
+    }
+
     protected static void UpdateChecksum(params WebConnection?[] connections)
     {
         connections.Where(connection => connection != null).Apply(connection => { connection!.PasswordChecksum = connection.CalculatedChecksum; });

--- a/FroniusMonitor/Models/Settings.cs
+++ b/FroniusMonitor/Models/Settings.cs
@@ -1,11 +1,7 @@
-﻿using De.Hochstaetter.Fronius.Models.Settings;
-
-namespace De.Hochstaetter.FroniusMonitor.Models;
+﻿namespace De.Hochstaetter.FroniusMonitor.Models;
 
 public class Settings : SettingsShared
 {
-    private static readonly object settingsLockObject = new();
-
     private Size? mainWindowSize;
     [DefaultValue(null),XmlElement("WindowSize")]
     public Size? MainWindowSize
@@ -40,43 +36,17 @@ public class Settings : SettingsShared
 
     public static Task Save() => Save(App.SettingsFileName);
 
-    public static async Task Save(string fileName) => await Task.Run(() =>
-    {
-        lock (settingsLockObject)
-        {
-            UpdateChecksum(App.Settings.WattPilotConnection, App.Settings.FritzBoxConnection, App.Settings.FroniusConnection, App.Settings.FroniusConnection2, App.Settings.ToshibaAcConnection);
-            var serializer = new XmlSerializer(typeof(Settings));
-            Directory.CreateDirectory(App.PerUserDataDir);
-            using var stream = new FileStream(fileName, FileMode.Create, FileAccess.Write, FileShare.None);
-
-            using var writer = XmlWriter.Create(stream, new XmlWriterSettings
-            {
-                Encoding = Encoding.UTF8,
-                Indent = true,
-                IndentChars = new string(' ', 3),
-                NewLineChars = Environment.NewLine,
-            });
-
-            serializer.Serialize(writer, App.Settings);
-        }
-    }).ConfigureAwait(false);
+    public static async Task Save(string fileName) => await Task.Run(() => Save<Settings>(App.Settings, fileName)).ConfigureAwait(false);
 
     public static async Task Load(string fileName) => await Task.Run(() =>
     {
-        lock (settingsLockObject)
+        try
         {
-            try
-            {
-                App.SolarSystemQueryTimer = new(_ => { Environment.Exit(0); }, null, 10000, -1);
-                var serializer = new XmlSerializer(typeof(Settings));
-                using var stream = new FileStream(fileName, FileMode.Open, FileAccess.Read, FileShare.Read);
-                App.Settings = serializer.Deserialize(stream) as Settings ?? new Settings();
-                ClearIncorrectPasswords(App.Settings.WattPilotConnection, App.Settings.FritzBoxConnection, App.Settings.FroniusConnection);
-            }
-            finally
-            {
-                App.SolarSystemQueryTimer?.Dispose();
-            }
+            App.Settings = Load<Settings>(fileName);
+        }
+        finally
+        {
+            App.SolarSystemQueryTimer?.Dispose();
         }
     }).ConfigureAwait(false);
 

--- a/FroniusPhone/Models/Settings.cs
+++ b/FroniusPhone/Models/Settings.cs
@@ -1,8 +1,4 @@
-﻿using System.Text;
-using System.Xml;
-using System.Xml.Serialization;
-using De.Hochstaetter.Fronius.Extensions;
-using De.Hochstaetter.Fronius.Models.Settings;
+﻿using De.Hochstaetter.Fronius.Extensions;
 
 namespace FroniusPhone.Models
 {
@@ -10,10 +6,7 @@ namespace FroniusPhone.Models
     {
         public void Load(string? fileName = null)
         {
-            fileName ??= App.SettingsFileName;
-            var serializer = new XmlSerializer(typeof(Settings));
-            var stream = new FileStream(fileName, FileMode.Open, FileAccess.Read, FileShare.Read);
-            var settings = serializer.Deserialize(stream) as Settings ?? new Settings();
+            var settings = Load<Settings>(fileName ?? App.SettingsFileName);
             typeof(Settings).GetProperties().Apply(propertyInfo => propertyInfo.SetValue(this, propertyInfo.GetValue(settings)));
         }
 
@@ -28,21 +21,7 @@ namespace FroniusPhone.Models
             {
                 Directory.CreateDirectory(App.PerUserDataDir);
             }
-
-            fileName ??= App.SettingsFileName;
-            UpdateChecksum(WattPilotConnection, FritzBoxConnection, FroniusConnection, FroniusConnection2, ToshibaAcConnection);
-            var serializer = new XmlSerializer(typeof(Settings));
-            using var stream = new FileStream(fileName, FileMode.Create, FileAccess.Write, FileShare.None);
-
-            using var writer = XmlWriter.Create(stream, new XmlWriterSettings
-            {
-                Encoding = Encoding.UTF8,
-                Indent = true,
-                IndentChars = new string(' ', 3),
-                NewLineChars = Environment.NewLine,
-            });
-
-            serializer.Serialize(writer, this);
+            Save<Settings>(this, fileName ?? App.SettingsFileName);
         }
 
         public async ValueTask SaveAsync(string? fileName = null)

--- a/HomeAutomationServer/Models/Settings/Settings.cs
+++ b/HomeAutomationServer/Models/Settings/Settings.cs
@@ -1,16 +1,10 @@
-﻿using System.Runtime.Serialization;
-using System.Text;
-using System.Xml;
-using System.Xml.Serialization;
-using De.Hochstaetter.Fronius.Extensions;
+﻿using System.Xml.Serialization;
 using De.Hochstaetter.Fronius.Models.Settings;
 
 namespace De.Hochstaetter.HomeAutomationServer.Models.Settings;
 
-public class Settings
+public class Settings : SettingsBase
 {
-    private static int settingLock;
-
     //[DefaultValue("0.0.0.0")]
     public string ServerIpAddress { get; set; } = "0.0.0.0";
 
@@ -23,64 +17,7 @@ public class Settings
 
     [XmlIgnore] public static string SettingsFileName { get; set; } = Path.Combine(AppContext.BaseDirectory, "Settings.xml");
 
-    public static async Task<Settings> LoadAsync(string? fileName = null)
-    {
-        while (Interlocked.Exchange(ref settingLock, 1) != 0)
-        {
-            await Task.Delay(TimeSpan.FromMilliseconds(20)).ConfigureAwait(false);
-        }
+    public static async Task<Settings> LoadAsync(string? fileName = null) => await Task.Run(() => Load<Settings>(fileName ?? SettingsFileName));
 
-        try
-        {
-            fileName ??= SettingsFileName;
-            await using var stream = new FileStream(fileName, FileMode.Open, FileAccess.Read, FileShare.Read);
-            var serializer = new XmlSerializer(typeof(Settings));
-            // ReSharper disable once AccessToDisposedClosure
-            return await Task.Run(() => serializer.Deserialize(stream) as Settings ?? throw new SerializationException()).ConfigureAwait(false);
-        }
-        finally
-        {
-            Interlocked.Exchange(ref settingLock, 0);
-        }
-    }
-
-    public static Settings Load(string? fileName = null) => LoadAsync(fileName).GetAwaiter().GetResult();
-
-    public async Task SaveAsync(string? fileName = null)
-    {
-        while (Interlocked.Exchange(ref settingLock, 1) != 0)
-        {
-            await Task.Delay(TimeSpan.FromMilliseconds(20)).ConfigureAwait(false);
-        }
-
-        try
-        {
-            fileName ??= SettingsFileName;
-            UpdateChecksum(FritzBoxConnections.ToArray());
-            var serializer = new XmlSerializer(typeof(Settings));
-            await using var stream = new FileStream(fileName, FileMode.Create, FileAccess.Write, FileShare.None);
-
-            await using var writer = XmlWriter.Create(stream, new XmlWriterSettings
-            {
-                Encoding = Encoding.UTF8,
-                Indent = true,
-                IndentChars = new string(' ', 3),
-                NewLineChars = Environment.NewLine,
-                Async = true,
-            });
-
-            serializer.Serialize(writer, this);
-        }
-        finally
-        {
-            Interlocked.Exchange(ref settingLock, 0);
-        }
-    }
-
-    public void Save(string? fileName = null) => SaveAsync(fileName).GetAwaiter().GetResult();
-
-    private static void UpdateChecksum(params WebConnection?[] connections)
-    {
-        connections.Where(connection => connection != null).Apply(connection => { connection!.PasswordChecksum = connection.CalculatedChecksum; });
-    }
+    public async Task SaveAsync(string? fileName = null) => await Task.Run(() => Save<Settings>(this, fileName ?? SettingsFileName));
 }


### PR DESCRIPTION
Unifies behavior across the applications, updating check-sums, clearing passwords etc. Still, gives enough flexibility to extend lodaing or saving settings if there is still a need. Use SemaphoreSlim to protect resource access instead of busy-waiting (polling with Task.Delay etc.).