### PR TITLE
Bug fix

### DIFF
--- a/FroniusShared/Models/HomeAutomationSystem.cs
+++ b/FroniusShared/Models/HomeAutomationSystem.cs
@@ -48,7 +48,11 @@ public class HomeAutomationSystem : BindableBase
     public Gen24PowerFlow? SitePowerFlow
     {
         get => sitePowerFlow;
-        set => Set(ref sitePowerFlow, value);
+        set => Set(ref sitePowerFlow, value, () =>
+        {
+            NotifyOfPropertyChange(nameof(GridPowerCorrected));
+            NotifyOfPropertyChange(nameof(LoadPowerCorrected));
+        });
     }
 
     private WattPilot? wattPilot;


### PR DESCRIPTION
Amend commit [6f7e694d19dfcd33733a7831d59cad700ebfa256](https://github.com/christoh/FroniusMonitor/pull/21/commits/6f7e694d19dfcd33733a7831d59cad700ebfa256), fix broken house consumption watts

Before commit 6f7e69, notifications about Load and or Grid power corrected
values was send while setting the either of these properties in Gen24PowerFlow.
Now we will send the update notification right after setting the SitePowerFlow
property.

Fixes: [Refactoring regarding meter history broke proper notification with INotifyProperyChange](https://github.com/christoh/FroniusMonitor/pull/28)